### PR TITLE
Refactor shared log consumer configuration

### DIFF
--- a/comm/confighelper.py
+++ b/comm/confighelper.py
@@ -1,0 +1,30 @@
+#coding=utf-8
+#!/usr/bin/python
+import ConfigParser
+
+
+class DBConfig(object):
+	"""Container for database and Kafka connection settings."""
+	def __init__(self, host, port, user, password, kafka_hosts):
+		self.host = host
+		self.port = port
+		self.user = user
+		self.password = password
+		self.kafka_hosts = kafka_hosts
+
+	def log_message(self):
+		return "dbhost:%s dbport%s dbuser:%s dbpwd:%s broker_hosts:%s" % (
+			self.host, self.port, self.user, self.password, self.kafka_hosts)
+
+
+def load_db_config(path="db.conf"):
+	"""Load the common DB/Kafka settings used by log consumers."""
+	cf = ConfigParser.ConfigParser()
+	cf.read(path)
+	return DBConfig(
+		cf.get("db", "db_host"),
+		cf.getint("db", "db_port"),
+		cf.get("db", "db_user"),
+		cf.get("db", "db_pass"),
+		cf.get("kafka", "broker_hosts"),
+	)

--- a/comm/dbhelper.py
+++ b/comm/dbhelper.py
@@ -21,10 +21,13 @@ class TaoleSessionDB(object):
 		except Exception, e:
 			print Exception,":",e
 			taolelogs.logroot.warn(e)
+			self.session.rollback()
 			result = None
 		return result
 
 	def close(self):
+		if not hasattr(self, 'session'):
+			return True
 		try:
 			self.session.close()
 		except Exception, e:
@@ -48,6 +51,8 @@ class dbhelper(object):
 			print Exception,e
 			taolelogs.logroot.warn(e)
 	def close(self):
+		if not hasattr(self, 'connect'):
+			return True
 		try:
 			self.connect.close()
 		except Exception, e:

--- a/comm/taolelogs.py
+++ b/comm/taolelogs.py
@@ -12,12 +12,14 @@ def InitailLogs(logname,level=logging.WARN):
 	if not os.path.exists('./logs/'):
 		os.makedirs('./logs/')
 	format = '%(asctime)s %(levelname)s %(module)s.%(funcName)s Line:%(lineno)d %(message)s'  
-	hdlr = TimedRotatingFileHandler("./logs/"+logname + '.log',"D")  
-	fmt = logging.Formatter(format)  
-	hdlr.setFormatter(fmt)  
 	logroot = logging.getLogger(logname)
-	logroot.addHandler(hdlr)  
 	logroot.setLevel(level)
+	if not logroot.handlers:
+		hdlr = TimedRotatingFileHandler("./logs/"+logname + '.log',"D")
+		fmt = logging.Formatter(format)
+		hdlr.setFormatter(fmt)
+		logroot.addHandler(hdlr)
+	logroot.propagate = False
 	return logroot
 	
 def GetTaoleLog():

--- a/sbowebapilogs/sbowebapilogs.py
+++ b/sbowebapilogs/sbowebapilogs.py
@@ -15,6 +15,7 @@ from EventsDefine import LoginType
 from tabledefine import TableNameS
 from EventsDefine import PayTypeName
 from dbhelper import TaoleSessionDB
+from confighelper import load_db_config
 session=None
 kafka_hosts=[]
 kafka_topic = ''
@@ -25,22 +26,16 @@ def InitialDB():
 	global kafka_hosts
 	global session
 	global kafka_topic
-	cf = ConfigParser.ConfigParser()
 	try:
-		cf.read("db.conf")
-		db_host = cf.get("db", "db_host")
-		db_port = cf.getint("db", "db_port")
-		db_user = cf.get("db", "db_user")
-		db_pass = cf.get("db", "db_pass")
-		kafka_hosts = cf.get("kafka","broker_hosts")
-		#kafka_topic = cf.get("kafka",'topic')
+		config = load_db_config()
 	except Exception, e:
 		print Exception,":",e
 		taolelogs.logroot.warn(e)
 		exit(0)
+	kafka_hosts = config.kafka_hosts
 	
-	print "dbhost:%s dbport%s dbuser:%s dbpwd:%s broker_hosts:%s"%(db_host,db_port,db_user,db_pass,kafka_hosts)
-	session = TaoleSessionDB(db_host,db_port,db_user,db_pass,'imsuibo')
+	print config.log_message()
+	session = TaoleSessionDB(config.host,config.port,config.user,config.password,'imsuibo')
 
 
 

--- a/suiboerroapi/suiboerroapi.py
+++ b/suiboerroapi/suiboerroapi.py
@@ -17,6 +17,7 @@ from EventsDefine import PayTypeName
 from xml.etree import ElementTree as ET
 from sendemail import sendEmail
 from dbhelper import TaoleSessionDB
+from confighelper import load_db_config
 import Queue
 session=None
 kafka_hosts=[]
@@ -65,23 +66,17 @@ def  readErrxml():
 def InitialDB():
 	global kafka_hosts
 	global kafka_topic
-	cf = ConfigParser.ConfigParser()
 	try:
-		cf.read("db.conf")
-		db_host = cf.get("db", "db_host")
-		db_port = cf.getint("db", "db_port")
-		db_user = cf.get("db", "db_user")
-		db_pass = cf.get("db", "db_pass")
-		kafka_hosts = cf.get("kafka","broker_hosts")
-		#kafka_topic = cf.get("kafka",'topic')
+		config = load_db_config()
 	except Exception, e:
 		print Exception,":",e
 		taolelogs.logroot.warn(e)
 		exit(0)
+	kafka_hosts = config.kafka_hosts
 	
-	print "dbhost:%s dbport%s dbuser:%s dbpwd:%s broker_hosts:%s"%(db_host,db_port,db_user,db_pass,kafka_hosts)
+	print config.log_message()
 	global session
-	session = TaoleSessionDB(db_host,db_port,db_user,db_pass,'imsuibo')
+	session = TaoleSessionDB(config.host,config.port,config.user,config.password,'imsuibo')
 
 
 

--- a/suibomobilecli/suibomobilecli.py
+++ b/suibomobilecli/suibomobilecli.py
@@ -9,29 +9,24 @@ import re
 import MySQLdb
 import taolelogs
 from dbhelper import TaoleSessionDB
+from confighelper import load_db_config
 session=None
 kafka_hosts=[]
 kafka_topic = ''
 def InitialDB():
 	global kafka_hosts
 	global kafka_topic
-	cf = ConfigParser.ConfigParser()
 	try:
-		cf.read("db.conf")
-		db_host = cf.get("db", "db_host")
-		db_port = cf.getint("db", "db_port")
-		db_user = cf.get("db", "db_user")
-		db_pass = cf.get("db", "db_pass")
-		kafka_hosts = cf.get("kafka","broker_hosts")
-		#kafka_topic = cf.get("kafka",'topic')
+		config = load_db_config()
 	except Exception, e:
 		print Exception,":",e
 		taolelogs.logroot.warn(e)
 		exit(0)
+	kafka_hosts = config.kafka_hosts
 	
-	print "dbhost:%s dbport%s dbuser:%s dbpwd:%s broker_hosts:%s"%(db_host,db_port,db_user,db_pass,kafka_hosts)
+	print config.log_message()
 	global session
-	session = TaoleSessionDB(db_host,db_port,db_user,db_pass,'imsuibo')
+	session = TaoleSessionDB(config.host,config.port,config.user,config.password,'imsuibo')
 
 
 

--- a/suibowebapi/webapisplitlog.py
+++ b/suibowebapi/webapisplitlog.py
@@ -14,6 +14,7 @@ from EventsDefine import LoginType
 from tabledefine import TableNameS
 from EventsDefine import PayTypeName
 from dbhelper import TaoleSessionDB
+from confighelper import load_db_config
 session=None
 kafka_hosts=[]
 kafka_topic = ''
@@ -22,23 +23,17 @@ kafka_topic = ''
 def InitialDB():
 	global kafka_hosts
 	global kafka_topic
-	cf = ConfigParser.ConfigParser()
 	try:
-		cf.read("db.conf")
-		db_host = cf.get("db", "db_host")
-		db_port = cf.getint("db", "db_port")
-		db_user = cf.get("db", "db_user")
-		db_pass = cf.get("db", "db_pass")
-		kafka_hosts = cf.get("kafka","broker_hosts")
-		#kafka_topic = cf.get("kafka",'topic')
+		config = load_db_config()
 	except Exception, e:
 		print Exception,":",e
 		taolelogs.logroot.warn(e)
 		exit(0)
+	kafka_hosts = config.kafka_hosts
 	
-	print "dbhost:%s dbport%s dbuser:%s dbpwd:%s broker_hosts:%s"%(db_host,db_port,db_user,db_pass,kafka_hosts)
+	print config.log_message()
 	global session
-	session = TaoleSessionDB(db_host,db_port,db_user,db_pass,'imsuibo')
+	session = TaoleSessionDB(config.host,config.port,config.user,config.password,'imsuibo')
 
 
 

--- a/tlewebapilogs/tlewebapilogs.py
+++ b/tlewebapilogs/tlewebapilogs.py
@@ -15,6 +15,7 @@ from tabledefine import TableNameS
 from EventsDefine import PayTypeName
 import taolelogs
 from dbhelper import TaoleSessionDB
+from confighelper import load_db_config
 
 session=None
 kafka_hosts=[]
@@ -25,20 +26,15 @@ def InitialDB():
 	global kafka_hosts
 	global session
 	global kafka_topic
-	cf = ConfigParser.ConfigParser()
 	try:
-		cf.read("db.conf")
-		db_host = cf.get("db", "db_host")
-		db_port = cf.getint("db", "db_port")
-		db_user = cf.get("db", "db_user")
-		db_pass = cf.get("db", "db_pass")
-		kafka_hosts = cf.get("kafka","broker_hosts")
+		config = load_db_config()
 	except Exception, e:
 		print Exception,":",e
 		taolelogs.logroot.warn(e)
 		exit(0)
-	print "dbhost:%s dbport%s dbuser:%s dbpwd:%s broker_hosts:%s"%(db_host,db_port,db_user,db_pass,kafka_hosts)
-	session = TaoleSessionDB(db_host,db_port,db_user,db_pass,'imsuibo')
+	kafka_hosts = config.kafka_hosts
+	print config.log_message()
+	session = TaoleSessionDB(config.host,config.port,config.user,config.password,'imsuibo')
 
 
 


### PR DESCRIPTION
### Motivation

- Reduce duplicated DB/Kafka parsing logic across multiple Kafka log consumer scripts by centralizing configuration loading. 
- Improve robustness of DB session handling to avoid leaving transactions open after failures. 
- Prevent duplicate logging handlers and noisy duplicate log propagation.

### Description

- Add `comm/confighelper.py` with `load_db_config()` and `DBConfig` to centralize reading `db.conf` and formatting a human-readable log message. 
- Update consumer entrypoints to use `load_db_config()` and `DBConfig` instead of repeating `ConfigParser` parsing in `suibowebapi/webapisplitlog.py`, `sbowebapilogs/sbowebapilogs.py`, `tlewebapilogs/tlewebapilogs.py`, `suiboerroapi/suiboerroapi.py`, and `suibomobilecli/suibomobilecli.py`. 
- Harden `comm/dbhelper.py` to call `self.session.rollback()` on execute exceptions and make `close()` safe when the session/connection attribute is not present. 
- Update `comm/taolelogs.py` to only add a `TimedRotatingFileHandler` when handlers are not already attached and disable propagation to avoid duplicate outputs.

### Testing

- Ran `git diff --check` and it returned clean results. (passed)
- Compiled the new helper with `python -m py_compile comm/confighelper.py` (passed). 
- Attempted to `py_compile` the other modified files under the current environment Python 3 interpreter and observed failures due to the repository using Python 2 syntax; this is an expected incompatibility and not caused by the refactor. (syntax check failed under Python 3 for legacy Python 2 code)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a048b6474832e8ad53acbec53c78a)