### PR TITLE
Harden database logging and SMTP configuration

### DIFF
--- a/comm/confighelper.py
+++ b/comm/confighelper.py
@@ -13,8 +13,9 @@ class DBConfig(object):
 		self.kafka_hosts = kafka_hosts
 
 	def log_message(self):
-		return "dbhost:%s dbport%s dbuser:%s dbpwd:%s broker_hosts:%s" % (
-			self.host, self.port, self.user, self.password, self.kafka_hosts)
+		"""Return connection metadata without exposing the database password."""
+		return "dbhost:%s dbport:%s dbuser:%s dbpwd:%s broker_hosts:%s" % (
+			self.host, self.port, self.user, "******", self.kafka_hosts)
 
 
 def load_db_config(path="db.conf"):

--- a/comm/sendemail.py
+++ b/comm/sendemail.py
@@ -1,21 +1,32 @@
 # encoding: utf-8
 #!/usr/bin/python
+import os
 import smtplib
 from email.mime.text import MIMEText
 from email.header import Header
-def sendEmail(subject,tousrs,fromstr,msg):
-	sender = 'redmine@taolesoft.com'
-	smtpserver = 'smtp.exmail.qq.com'
-	username = 'redmine@taolesoft.com'
-	password = 'taole88'
-	msg = MIMEText(msg, 'plain', 'utf-8')
-	msg['Subject'] = Header(subject, 'utf-8')
-	msg['from'] = fromstr
-	msg['to'] = ",".join(tousrs)
-	smtp = smtplib.SMTP()
-	smtp.connect('smtp.exmail.qq.com')
-	smtp.login(username, password)
-	smtp.sendmail(sender, tousrs, msg.as_string())
-	smtp.quit()
 
-#sendEmail('fdf',['whg@taolesoft.com','76980374@qq.com'],'dgdfg','报')
+
+DEFAULT_SMTP_SERVER = 'smtp.exmail.qq.com'
+DEFAULT_SMTP_USER = 'redmine@taolesoft.com'
+
+
+def sendEmail(subject, tousrs, fromstr, msg):
+	"""Send an email using credentials supplied through the environment."""
+	smtpserver = os.environ.get('SMTP_SERVER', DEFAULT_SMTP_SERVER)
+	username = os.environ.get('SMTP_USERNAME', DEFAULT_SMTP_USER)
+	password = os.environ.get('SMTP_PASSWORD')
+	if not password:
+		raise ValueError('SMTP_PASSWORD environment variable is required')
+
+	message = MIMEText(msg, 'plain', 'utf-8')
+	message['Subject'] = Header(subject, 'utf-8')
+	message['From'] = fromstr
+	message['To'] = ",".join(tousrs)
+
+	smtp = smtplib.SMTP()
+	try:
+		smtp.connect(smtpserver)
+		smtp.login(username, password)
+		smtp.sendmail(username, tousrs, message.as_string())
+	finally:
+		smtp.quit()

--- a/comm/sendemail.py
+++ b/comm/sendemail.py
@@ -23,9 +23,8 @@ def sendEmail(subject, tousrs, fromstr, msg):
 	message['From'] = fromstr
 	message['To'] = ",".join(tousrs)
 
-	smtp = smtplib.SMTP()
+	smtp = smtplib.SMTP(smtpserver)
 	try:
-		smtp.connect(smtpserver)
 		smtp.login(username, password)
 		smtp.sendmail(username, tousrs, message.as_string())
 	finally:


### PR DESCRIPTION
## What changed

- Redact the database password from `DBConfig.log_message()` output and fix the missing `dbport:` separator.
- Remove the hard-coded SMTP password from source control.
- Read SMTP server, username, and password from environment variables.
- Ensure the SMTP connection is closed even when authentication or sending fails.

## Why

Credentials should not be committed to source control or emitted in application logs. Environment-based configuration also makes the mail helper safer to deploy across environments.

## Deployment impact

Set `SMTP_PASSWORD` before sending email. `SMTP_SERVER` and `SMTP_USERNAME` are optional and retain the existing server/account defaults.

Because the previous SMTP password was committed publicly, it should be rotated separately.

## Validation

- Compared the branch against `qiakr`; only `comm/confighelper.py` and `comm/sendemail.py` changed.
- Verified both modified modules parse successfully with Python's compiler.